### PR TITLE
[fix] Avoid to get a 404 error on logout

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,4 +1,4 @@
-location PATHTOCHANGE/ {
+location PATHTOCHANGE {
        alias ALIASTOCHANGE;
        if ($scheme = http) {
             rewrite ^ https://$server_name$request_uri? permanent;


### PR DESCRIPTION
This change allows to access to an URL without the end slash (like https//domain.tld/owncloud ). Owncloud calls this URL on logout.