### PR TITLE
Debian Jessie compatibility

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -242,3 +242,4 @@ php_value[upload_max_filesize] = 10G
 php_value[post_max_size] = 10G
 php_value[session.save_path] = /var/www/NAMETOCHANGE/lib/private/session/
 php_value[default_charset] = UTF-8
+php_value[always_populate_raw_post_data] = -1


### PR DESCRIPTION
Owncloud broken after update to jessie, need always_populate_raw_post_data at -1.
See : https://forum.yunohost.org/t/debian-8-0-jessie-beta-compatibility/601/4?u=shnoulle