### PR TITLE
Update to nginx.conf template to fix some paths

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -6,23 +6,20 @@ location LOCATIONTOCHANGE {
     
     #fastcgi_buffers 64 4K;
 
-    rewrite ^PATHTOCHANGE/caldav(.*)$ /remote.php/caldav$1 redirect;
-    rewrite ^PATHTOCHANGE/carddav(.*)$ /remote.php/carddav$1 redirect;
-    rewrite ^PATHTOCHANGE/webdav(.*)$ /remote.php/webdav$1 redirect;
+    rewrite ^PATHTOCHANGE/caldav(.*)$ PATHTOCHANGE/remote.php/caldav$1 redirect;
+    rewrite ^PATHTOCHANGE/carddav(.*)$ PATHTOCHANGE/remote.php/carddav$1 redirect;
+    rewrite ^PATHTOCHANGE/webdav(.*)$ PATHTOCHANGE/remote.php/webdav$1 redirect;
 
     error_page 403 PATHTOCHANGE/core/templates/403.php;
     error_page 404 PATHTOCHANGE/core/templates/404.php;
 
-    rewrite ^PATHTOCHANGE/.well-known/host-meta /public.php?service=host-meta last;
-    rewrite ^PATHTOCHANGE/.well-known/host-meta.json /public.php?service=host-meta-json last;
+    rewrite ^PATHTOCHANGE/.well-known/host-meta PATHTOCHANGE/public.php?service=host-meta last;
+    rewrite ^PATHTOCHANGE/.well-known/host-meta.json PATHTOCHANGE/public.php?service=host-meta-json last;
 
-    rewrite ^PATHTOCHANGE/.well-known/carddav /remote.php/carddav/ redirect;
-    rewrite ^PATHTOCHANGE/.well-known/caldav /remote.php/caldav/ redirect;
+    rewrite ^PATHTOCHANGE/.well-known/carddav PATHTOCHANGE/remote.php/carddav/ redirect;
+    rewrite ^PATHTOCHANGE/.well-known/caldav PATHTOCHANGE/remote.php/caldav/ redirect;
 
     rewrite ^(PATHTOCHANGE/core/doc/[^\/]+/)$ $1/index.html;
-
-    error_page 403 /core/templates/403.php;
-    error_page 404 /core/templates/404.php;
 
     client_max_body_size 10G;
     index index.php;


### PR DESCRIPTION
Added "PATHTOCHANGE" to each rewrite destination path, so that the client "stays" in owncloud's subdirectory (in my case, it fixed the .well-known URIs that otherwise didn't work)

Removed lines 24 and 25, which were incorrect, and unnecessary since the correct settings are found on lines 12 and 13.