### PR TITLE
Ajout yunohost.multimedia

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -57,6 +57,13 @@ trap exit_properly ERR
 sudo useradd -d /var/www/$APP $APP \
 	|| exit_properly
 
+# Add yunohost.multimedia directory
+wget https://github.com/maniackcrudelis/yunohost.multimedia/archive/master.zip
+unzip master.zip
+sudo ./yunohost.multimedia-master/script/ynh_media_build.sh
+# Add access to yunohost.multimedia dir
+sudo usermod -a -G multimedia $APP
+
 # Verify sources and extract it
 sha256sum --strict --quiet -c ../sources/$SOURCES.tar.bz2.sha256sum < ../sources/$SOURCES.tar.bz2
 gpg --import ../sources/$APPNAME.asc

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,6 +22,13 @@ path=${path%/}
 # Use 'owncloud' as database name and user \
 db_user=owncloud
 
+# Add yunohost.multimedia directory
+wget https://github.com/maniackcrudelis/yunohost.multimedia/archive/master.zip
+unzip master.zip
+sudo ./yunohost.multimedia-master/script/ynh_media_build.sh
+# Add access to yunohost.multimedia dir
+sudo usermod -a -G multimedia $APP
+
 # Verify sources and extract it
 sha256sum --strict --quiet -c ../sources/$SOURCES.tar.bz2.sha256sum < ../sources/$SOURCES.tar.bz2
 gpg --import ../sources/$APPNAME.asc


### PR DESCRIPTION
Intégration de la prise en charge du dossier yunohost.multimedia

Création (ou mise à jour) des dossiers multimédias et ajout de l'user owncloud au groupe multimedia afin qu'il ai le droit d'écriture sur l'ensemble des dossiers multimédias.

Le code est volontairement placé avant l'installation de owncloud, afin d'éviter des problèmes de mise à jour de l'arborescence de dossier sur owncloud. Sinon, il peine à prendre en compte ses droits sans mise à jour manuelle de la bdd ou ajout d'un fichier quelconque dans le dossier.