### PR TITLE
"-qq" in apt-get update is nice but hides the situation where dpkg is in a broken state

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -24,7 +24,7 @@ sudo yunohost app checkurl $domain$path -a $APP \
 path=${path%/}
 
 # Install dependencies
-sudo apt-get update -qq
+sudo apt-get update
 sudo apt-get install acl smbclient php5-cli php-apc coreutils gnupg tar -y -qq
 
 # Generate random password


### PR DESCRIPTION
For example the user won't be able to see "blabla broken, you need to run « apt-get install -f »" or similar things.